### PR TITLE
Export encode->matrix and encode->image from mare5x.lispqr.encode package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To write to PNG files, you will need to install [_zpng_](https://www.xach.com/li
 ;; (ql:quickload "lispqr")
 
 ;; Change into the 'encode' package.
-(in-package :mare5x.lispqr.encode)
+(in-package :mare5x.lispqr.encode)  ;; (in-package :lispqr)
 
 ;; Encode to a PNG image file.
 (encode->image "https://github.com/mare5x" "test.png" :ec-level :H)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -63,5 +63,8 @@
    :mare5x.lispqr.utils
    :mare5x.lispqr.galois
    :mare5x.lispqr.matrix
-   :mare5x.lispqr.image))
+   :mare5x.lispqr.image)
+  (:export
+   :encode->matrix
+   :encode->image))
 

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -58,6 +58,7 @@
    :make-qr-matrix))
 
 (defpackage :mare5x.lispqr.encode
+  (:nicknames :lispqr)
   (:use
    :common-lisp
    :mare5x.lispqr.utils


### PR DESCRIPTION
These functions are the main functionality of the system.

Probably, package `mare5x.lispqr.encode` should also be given a nickname `lispqr`.